### PR TITLE
Add generic ROS 2 msg schema bundle generator

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Start here for detailed specifications and guidance.
 - PDU binary format and epoch rules: `docs/specs/pdu-binary-format.md`
 - Godot binding design: `docs/specs/godot-binding-design.md`
 - Binary conversion test specification: `test-spec-binary-conversion.md`
+- ROS 2 `.msg` schema bundle generator: `docs/ros2msg-bundle-generator.md`

--- a/docs/ros2msg-bundle-generator.md
+++ b/docs/ros2msg-bundle-generator.md
@@ -1,0 +1,83 @@
+# ROS 2 `.msg` schema bundle generator
+
+`hakoniwa-pdu-registry` can generate a self-contained `ros2msg` schema bundle directly from ROS 2 `.msg` source files.
+
+The generated format is suitable for schema-aware consumers such as Foxglove and MCAP. The top-level `.msg` definition is followed by all transitive message dependencies using the standard delimiter form:
+
+```text
+================================================================================
+MSG: package/msg/Type
+```
+
+The generator is intentionally source-based:
+
+- no ROS 2 Python message bindings are imported;
+- no interface package is compiled;
+- no PDU offset calculation or C/C++ compilation is run;
+- unresolved dependencies are errors rather than silently producing a partial bundle.
+
+## Recommended: run from any host directory through Docker
+
+The host-side wrapper uses the pinned `hakoniwa-pdu-registry` Docker image and exits after generating the file. You do not need to open an interactive shell in the container.
+
+For example, from a sibling `hakoniwa-pdu-foxglove` checkout:
+
+```bash
+bash ../hakoniwa-pdu-registry/tools/generate_ros2msg_bundle.bash \
+  sensor_msgs/JointState \
+  -o ./work/schemas/ros2_jazzy/sensor_msgs/msg/JointState.bundle.msg
+```
+
+The wrapper:
+
+1. locates the registry Docker image from `docker/image_name.txt` and `docker/latest_version.txt`;
+2. pulls the image automatically when it is not available locally;
+3. mounts the registry read-only;
+4. mounts the requested output directory;
+5. searches the ROS 2 message packages installed in the image plus the registry `idl/` tree;
+6. runs `tools/generate_ros2msg_bundle.py` inside the container;
+7. writes the generated bundle directly to the host path supplied with `-o`.
+
+On Apple Silicon macOS, the wrapper uses `linux/amd64`, matching the existing registry Docker workflow.
+
+## Custom message packages
+
+Additional host-side message roots can be mounted with repeatable `--search-path` options. A search root must contain paths such as `<package>/msg/<Type>.msg`.
+
+```bash
+bash ../hakoniwa-pdu-registry/tools/generate_ros2msg_bundle.bash \
+  my_msgs/msg/MyMessage \
+  --search-path ../my_ros_interfaces/install/share \
+  -o ./work/schemas/MyMessage.bundle.msg
+```
+
+The default search order is:
+
+1. `/opt/ros/<ROS_VERSION>/share` inside the registry Docker image;
+2. `hakoniwa-pdu-registry/idl`;
+3. any extra `--search-path` directories in command-line order.
+
+## Direct Python use
+
+The underlying generator is standard-library-only and can also be run directly when the required `.msg` source trees already exist on the host:
+
+```bash
+python3 tools/generate_ros2msg_bundle.py \
+  sensor_msgs/JointState \
+  --search-path /path/to/ros/share \
+  --search-path ./idl \
+  -o JointState.bundle.msg
+```
+
+Accepted top-level type names are both:
+
+```text
+sensor_msgs/JointState
+sensor_msgs/msg/JointState
+```
+
+The resolver handles transitive dependencies, same-package message references, arrays, bounded arrays, strings, and bounded strings. Each dependency is emitted once in deterministic dependency-discovery order.
+
+## Responsibility boundary
+
+This tool belongs in `hakoniwa-pdu-registry` because the registry already owns ROS 2 `.msg` inputs and dependency resolution. Consumers such as `hakoniwa-pdu-foxglove` should stage the generated schema bundle in their local work area rather than hand-maintaining concatenated message definitions.

--- a/tests/test_generate_ros2msg_bundle.py
+++ b/tests/test_generate_ros2msg_bundle.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TOOL_PATH = Path(__file__).resolve().parents[1] / "tools" / "generate_ros2msg_bundle.py"
+SPEC = importlib.util.spec_from_file_location("generate_ros2msg_bundle", TOOL_PATH)
+assert SPEC is not None and SPEC.loader is not None
+bundle_tool = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundle_tool)
+
+
+class Ros2MsgBundleTest(unittest.TestCase):
+    def write_msg(self, root: Path, package: str, message: str, text: str) -> None:
+        path = root / package / "msg" / f"{message}.msg"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def test_joint_state_resolves_transitive_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_msg(
+                root,
+                "sensor_msgs",
+                "JointState",
+                "std_msgs/Header header\n"
+                "string[] name\n"
+                "float64[] position\n"
+                "float64[] velocity\n"
+                "float64[] effort\n",
+            )
+            self.write_msg(
+                root,
+                "std_msgs",
+                "Header",
+                "builtin_interfaces/Time stamp\nstring frame_id\n",
+            )
+            self.write_msg(
+                root,
+                "builtin_interfaces",
+                "Time",
+                "int32 sec\nuint32 nanosec\n",
+            )
+
+            top, deps = bundle_tool.resolve_bundle("sensor_msgs/JointState", [root])
+            rendered = bundle_tool.render_bundle(top, deps)
+
+            self.assertEqual(
+                [name for name, _ in deps],
+                ["std_msgs/msg/Header", "builtin_interfaces/msg/Time"],
+            )
+            self.assertTrue(rendered.startswith("std_msgs/Header header\n"))
+            self.assertIn(
+                f"{bundle_tool.SEPARATOR}\nMSG: std_msgs/msg/Header\n",
+                rendered,
+            )
+            self.assertIn(
+                f"{bundle_tool.SEPARATOR}\nMSG: builtin_interfaces/msg/Time\n",
+                rendered,
+            )
+
+    def test_same_package_bounded_types_and_arrays(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_msg(
+                root,
+                "demo_msgs",
+                "Outer",
+                "string<=32 label\nInner[<=4] items\nuint8[16] digest\n",
+            )
+            self.write_msg(root, "demo_msgs", "Inner", "float64 value\n")
+
+            _, deps = bundle_tool.resolve_bundle("demo_msgs/msg/Outer", [root])
+
+            self.assertEqual([name for name, _ in deps], ["demo_msgs/msg/Inner"])
+
+    def test_missing_dependency_fails_instead_of_emitting_partial_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.write_msg(root, "demo_msgs", "Outer", "missing_msgs/Missing value\n")
+
+            with self.assertRaises(bundle_tool.BundleError):
+                bundle_tool.resolve_bundle("demo_msgs/Outer", [root])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generate_ros2msg_bundle.bash
+++ b/tools/generate_ros2msg_bundle.bash
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REGISTRY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+CALLER_DIR="$(pwd -P)"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  generate_ros2msg_bundle.bash <message-type> -o <output> [--search-path <dir>]...
+
+Examples:
+  bash ../hakoniwa-pdu-registry/tools/generate_ros2msg_bundle.bash \
+    sensor_msgs/JointState \
+    -o ./work/schemas/ros2_jazzy/sensor_msgs/msg/JointState.bundle.msg
+
+  bash ../hakoniwa-pdu-registry/tools/generate_ros2msg_bundle.bash \
+    my_msgs/msg/MyMessage \
+    --search-path ../my_ros_interfaces/install/share \
+    -o ./work/schemas/MyMessage.bundle.msg
+
+The wrapper runs the pure-Python generator inside the pinned
+hakoniwa-pdu-registry Docker image. No interactive shell and no ROS 2 runtime on
+the host are required.
+EOF
+}
+
+MESSAGE_TYPE=""
+OUTPUT_PATH=""
+SEARCH_PATHS=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o|--output)
+            if [ "$#" -lt 2 ]; then
+                echo "error: $1 requires a path" >&2
+                exit 2
+            fi
+            OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        --search-path)
+            if [ "$#" -lt 2 ]; then
+                echo "error: --search-path requires a directory" >&2
+                exit 2
+            fi
+            SEARCH_PATHS+=("$2")
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -* )
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [ -n "${MESSAGE_TYPE}" ]; then
+                echo "error: multiple message types specified: ${MESSAGE_TYPE} and $1" >&2
+                exit 2
+            fi
+            MESSAGE_TYPE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "${MESSAGE_TYPE}" ] || [ -z "${OUTPUT_PATH}" ]; then
+    usage >&2
+    exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "error: docker command not found" >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "error: Docker is not running or is not accessible" >&2
+    exit 1
+fi
+
+IMAGE_NAME="$(cat "${REGISTRY_DIR}/docker/image_name.txt")"
+IMAGE_TAG="$(cat "${REGISTRY_DIR}/docker/latest_version.txt")"
+DOCKER_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+ROS_DISTRO="$(cat "${REGISTRY_DIR}/ROS_VERSION.txt")"
+
+if ! docker image inspect "${DOCKER_IMAGE}" >/dev/null 2>&1; then
+    echo "Docker image ${DOCKER_IMAGE} is not available locally; pulling it..."
+    docker pull "${DOCKER_IMAGE}"
+fi
+
+OUTPUT_DIR="$(dirname "${OUTPUT_PATH}")"
+OUTPUT_NAME="$(basename "${OUTPUT_PATH}")"
+mkdir -p "${OUTPUT_DIR}"
+OUTPUT_DIR_ABS="$(cd "${OUTPUT_DIR}" && pwd -P)"
+
+DOCKER_ARGS=(
+    run
+    --rm
+    --user "$(id -u):$(id -g)"
+    --volume "${REGISTRY_DIR}:/hako-registry:ro"
+    --volume "${OUTPUT_DIR_ABS}:/hako-output"
+)
+
+OS_TYPE="$(uname)"
+ARCH="$(arch)"
+if [ "${OS_TYPE}" = "Darwin" ] && [ "${ARCH}" = "arm64" ]; then
+    DOCKER_ARGS+=(--platform linux/amd64)
+fi
+
+PYTHON_ARGS=(
+    python3
+    /hako-registry/tools/generate_ros2msg_bundle.py
+    "${MESSAGE_TYPE}"
+    --search-path "/opt/ros/${ROS_DISTRO}/share"
+    --search-path /hako-registry/idl
+    -o "/hako-output/${OUTPUT_NAME}"
+)
+
+SEARCH_INDEX=0
+for SEARCH_PATH in "${SEARCH_PATHS[@]}"; do
+    if [ ! -d "${SEARCH_PATH}" ]; then
+        echo "error: search path is not a directory: ${SEARCH_PATH}" >&2
+        exit 2
+    fi
+    SEARCH_PATH_ABS="$(cd "${SEARCH_PATH}" && pwd -P)"
+    CONTAINER_SEARCH_PATH="/hako-search/${SEARCH_INDEX}"
+    DOCKER_ARGS+=(--volume "${SEARCH_PATH_ABS}:${CONTAINER_SEARCH_PATH}:ro")
+    PYTHON_ARGS+=(--search-path "${CONTAINER_SEARCH_PATH}")
+    SEARCH_INDEX=$((SEARCH_INDEX + 1))
+done
+
+printf 'Generating %s -> %s\n' "${MESSAGE_TYPE}" "${OUTPUT_DIR_ABS}/${OUTPUT_NAME}"
+docker "${DOCKER_ARGS[@]}" "${DOCKER_IMAGE}" "${PYTHON_ARGS[@]}"

--- a/tools/generate_ros2msg_bundle.py
+++ b/tools/generate_ros2msg_bundle.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Generate a self-contained MCAP/Foxglove ros2msg schema bundle from ROS 2 .msg files.
+
+This tool intentionally operates on source .msg files only. It does not import ROS 2
+Python bindings and does not compile interface packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+SEPARATOR = "=" * 80
+
+PRIMITIVE_TYPES = {
+    "bool",
+    "byte",
+    "char",
+    "float32",
+    "float64",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "string",
+    "wstring",
+}
+
+ARRAY_SUFFIX_RE = re.compile(r"\[[^\]]*\]$")
+BOUNDED_STRING_RE = re.compile(r"^(?:w?string)(?:<=\d+)?$")
+
+
+class BundleError(RuntimeError):
+    """Raised when a message bundle cannot be resolved completely."""
+
+
+def normalize_message_type(type_name: str, default_package: str | None = None) -> str | None:
+    """Return canonical ``package/msg/Type`` or ``None`` for primitive types."""
+    base = type_name.strip()
+    while ARRAY_SUFFIX_RE.search(base):
+        base = ARRAY_SUFFIX_RE.sub("", base)
+
+    if base in PRIMITIVE_TYPES or BOUNDED_STRING_RE.fullmatch(base):
+        return None
+
+    parts = base.split("/")
+    if len(parts) == 3 and parts[1] == "msg":
+        package, _, message = parts
+        if package and message:
+            return f"{package}/msg/{message}"
+    elif len(parts) == 2:
+        package, message = parts
+        if package and message:
+            return f"{package}/msg/{message}"
+    elif len(parts) == 1 and default_package:
+        return f"{default_package}/msg/{base}"
+
+    raise BundleError(f"Unsupported ROS 2 message type syntax: {type_name!r}")
+
+
+def split_canonical_type(canonical_type: str) -> tuple[str, str]:
+    parts = canonical_type.split("/")
+    if len(parts) != 3 or parts[1] != "msg" or not parts[0] or not parts[2]:
+        raise BundleError(f"Expected package/msg/Type, got: {canonical_type!r}")
+    return parts[0], parts[2]
+
+
+def find_message_file(search_paths: Iterable[Path], canonical_type: str) -> Path:
+    package, message = split_canonical_type(canonical_type)
+    checked: list[Path] = []
+
+    for root in search_paths:
+        candidate = root / package / "msg" / f"{message}.msg"
+        checked.append(candidate)
+        if candidate.is_file():
+            return candidate
+
+        # Also accept a package-share directory itself as a search path.
+        if root.name == package:
+            candidate = root / "msg" / f"{message}.msg"
+            checked.append(candidate)
+            if candidate.is_file():
+                return candidate
+
+    checked_text = "\n".join(f"  - {path}" for path in checked)
+    raise BundleError(f"Could not resolve {canonical_type}. Checked:\n{checked_text}")
+
+
+def iter_field_types(message_text: str) -> Iterable[str]:
+    """Yield field type tokens from a ROS 2 .msg source definition."""
+    for raw_line in message_text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or "=" in line:
+            continue
+        parts = line.split()
+        if len(parts) >= 2:
+            yield parts[0]
+
+
+def resolve_bundle(
+    top_level_type: str,
+    search_paths: Iterable[Path],
+) -> tuple[str, list[tuple[str, str]]]:
+    """Resolve the top-level source plus all transitive .msg dependencies."""
+    canonical_top = normalize_message_type(top_level_type)
+    if canonical_top is None:
+        raise BundleError("Top-level type must be a ROS 2 message type, not a primitive")
+
+    resolved: dict[str, str] = {}
+    visiting: set[str] = set()
+    dependency_order: list[str] = []
+
+    def visit(canonical_type: str, *, is_top_level: bool = False) -> None:
+        if canonical_type in resolved:
+            return
+        if canonical_type in visiting:
+            raise BundleError(f"Cyclic message dependency detected at {canonical_type}")
+
+        visiting.add(canonical_type)
+        package, _ = split_canonical_type(canonical_type)
+        source_path = find_message_file(search_paths, canonical_type)
+        try:
+            source_text = source_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise BundleError(f"Message file is not UTF-8: {source_path}") from exc
+
+        resolved[canonical_type] = source_text
+        if not is_top_level:
+            dependency_order.append(canonical_type)
+
+        for field_type in iter_field_types(source_text):
+            dependency = normalize_message_type(field_type, default_package=package)
+            if dependency is not None:
+                visit(dependency)
+
+        visiting.remove(canonical_type)
+
+    visit(canonical_top, is_top_level=True)
+    return resolved[canonical_top], [
+        (canonical_type, resolved[canonical_type]) for canonical_type in dependency_order
+    ]
+
+
+def render_bundle(top_level_text: str, dependencies: Iterable[tuple[str, str]]) -> str:
+    chunks = [top_level_text.rstrip("\n")]
+    for canonical_type, source_text in dependencies:
+        chunks.extend([SEPARATOR, f"MSG: {canonical_type}", source_text.rstrip("\n")])
+    return "\n".join(chunks) + "\n"
+
+
+def read_search_path_file(path: Path) -> list[Path]:
+    paths: list[Path] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        paths.append(Path(os.path.expandvars(os.path.expanduser(line))))
+    return paths
+
+
+def default_search_paths() -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    paths = [repo_root / "idl"]
+    ros_distro = os.environ.get("ROS_DISTRO")
+    if ros_distro:
+        paths.insert(0, Path(f"/opt/ros/{ros_distro}/share"))
+    return paths
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a self-contained MCAP/Foxglove ros2msg schema bundle "
+            "directly from ROS 2 .msg source files."
+        )
+    )
+    parser.add_argument(
+        "message_type",
+        help="Top-level message type, e.g. sensor_msgs/JointState or sensor_msgs/msg/JointState",
+    )
+    parser.add_argument("-o", "--output", required=True, help="Output bundle file")
+    parser.add_argument(
+        "--search-path",
+        action="append",
+        default=[],
+        help="Message search root containing <package>/msg/<Type>.msg; repeatable",
+    )
+    parser.add_argument(
+        "--search-path-file",
+        help="Optional newline-separated message search roots",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    search_paths: list[Path] = []
+    if args.search_path_file:
+        search_paths.extend(read_search_path_file(Path(args.search_path_file)))
+    search_paths.extend(Path(path) for path in args.search_path)
+    if not search_paths:
+        search_paths = default_search_paths()
+
+    search_paths = [path.resolve() for path in search_paths]
+
+    try:
+        top_level_text, dependencies = resolve_bundle(args.message_type, search_paths)
+        bundle = render_bundle(top_level_text, dependencies)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(bundle, encoding="utf-8")
+    except (BundleError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"generated {output_path} "
+        f"(message={args.message_type}, dependencies={len(dependencies)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a generic, source-only ROS 2 `.msg` schema bundle generator owned by `hakoniwa-pdu-registry`.

The goal is to replace hand-maintained Foxglove/MCAP `ros2msg` bundles with a reusable registry capability that resolves `.msg` dependencies recursively without importing generated ROS 2 Python bindings or compiling interface packages.

## Host-side usage

From a sibling repository such as `hakoniwa-pdu-foxglove`:

```bash
bash ../hakoniwa-pdu-registry/tools/generate_ros2msg_bundle.bash \
  sensor_msgs/JointState \
  -o ./work/schemas/ros2_jazzy/sensor_msgs/msg/JointState.bundle.msg
```

The wrapper automatically:

- locates the pinned registry Docker image
- pulls it when absent locally
- runs non-interactively with `--rm`
- mounts the registry read-only
- mounts the requested host output directory
- searches `/opt/ros/<ROS_VERSION>/share` plus the registry `idl/` tree
- invokes the pure-Python generator inside the container
- writes the result directly to the caller's `-o` path
- uses `linux/amd64` on Apple Silicon macOS, matching the existing Docker workflow

Custom host message roots can be added with repeatable `--search-path` options.

## Bundle format

The generated schema follows the MCAP/Foxglove `ros2msg` concatenated message-definition format: the top-level `.msg` source appears first, followed by transitive dependencies delimited by 80 `=` characters and `MSG: package/msg/Type` headers.

Unresolved dependencies are treated as errors so the tool never silently emits a partial bundle.

## Files

- `tools/generate_ros2msg_bundle.py`: standard-library-only resolver and bundle writer
- `tools/generate_ros2msg_bundle.bash`: one-shot Docker wrapper for use from external repositories
- `tests/test_generate_ros2msg_bundle.py`: JointState-style transitive dependency, bounded-type, and missing-dependency tests
- `docs/ros2msg-bundle-generator.md`: usage and responsibility boundary
- `docs/README.md`: documentation index entry

## Validation

I could not run the local unit tests in my execution environment because outbound GitHub access is unavailable there. The implementation is intentionally isolated from the existing PDU generation path; no existing generator or binary-layout behavior is changed.

## Scope

This is not Foxglove-specific transport code. It is a generic `ROS 2 .msg -> self-contained ros2msg schema bundle` capability that can be consumed by Foxglove, MCAP, or other schema-aware integrations.