### PR TITLE
Fix ros2msg dependency labels

### DIFF
--- a/docs/ros2msg-bundle-generator.md
+++ b/docs/ros2msg-bundle-generator.md
@@ -6,8 +6,10 @@ The generated format is suitable for schema-aware consumers such as Foxglove and
 
 ```text
 ================================================================================
-MSG: package/msg/Type
+MSG: package/Type
 ```
+
+The dependency label intentionally uses the same two-part `package/Type` form that appears inside ROS 2 `.msg` field definitions. For example, a field declared as `std_msgs/Header header` is paired with `MSG: std_msgs/Header`. The internal resolver may normalize types to `package/msg/Type`, but that canonical lookup form is not written into the concatenated schema bundle.
 
 The generator is intentionally source-based:
 

--- a/tests/test_generate_ros2msg_bundle.py
+++ b/tests/test_generate_ros2msg_bundle.py
@@ -55,13 +55,14 @@ class Ros2MsgBundleTest(unittest.TestCase):
             )
             self.assertTrue(rendered.startswith("std_msgs/Header header\n"))
             self.assertIn(
-                f"{bundle_tool.SEPARATOR}\nMSG: std_msgs/msg/Header\n",
+                f"{bundle_tool.SEPARATOR}\nMSG: std_msgs/Header\n",
                 rendered,
             )
             self.assertIn(
-                f"{bundle_tool.SEPARATOR}\nMSG: builtin_interfaces/msg/Time\n",
+                f"{bundle_tool.SEPARATOR}\nMSG: builtin_interfaces/Time\n",
                 rendered,
             )
+            self.assertNotIn("MSG: std_msgs/msg/Header", rendered)
 
     def test_same_package_bounded_types_and_arrays(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -75,8 +76,10 @@ class Ros2MsgBundleTest(unittest.TestCase):
             self.write_msg(root, "demo_msgs", "Inner", "float64 value\n")
 
             _, deps = bundle_tool.resolve_bundle("demo_msgs/msg/Outer", [root])
+            rendered = bundle_tool.render_bundle("Inner[<=4] items\n", deps)
 
             self.assertEqual([name for name, _ in deps], ["demo_msgs/msg/Inner"])
+            self.assertIn("MSG: demo_msgs/Inner\n", rendered)
 
     def test_missing_dependency_fails_instead_of_emitting_partial_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/generate_ros2msg_bundle.py
+++ b/tools/generate_ros2msg_bundle.py
@@ -73,6 +73,18 @@ def split_canonical_type(canonical_type: str) -> tuple[str, str]:
     return parts[0], parts[2]
 
 
+def bundle_resource_name(canonical_type: str) -> str:
+    """Return the dependency name used by concatenated ros2msg schema text.
+
+    ROS 2 field definitions refer to nested messages as ``package/Type``. Foxglove
+    resolves dependency sections against those names, so dependency delimiters must
+    use the same two-part form even though the top-level schema name may use
+    ``package/msg/Type`` elsewhere in the transport metadata.
+    """
+    package, message = split_canonical_type(canonical_type)
+    return f"{package}/{message}"
+
+
 def find_message_file(search_paths: Iterable[Path], canonical_type: str) -> Path:
     package, message = split_canonical_type(canonical_type)
     checked: list[Path] = []
@@ -152,7 +164,13 @@ def resolve_bundle(
 def render_bundle(top_level_text: str, dependencies: Iterable[tuple[str, str]]) -> str:
     chunks = [top_level_text.rstrip("\n")]
     for canonical_type, source_text in dependencies:
-        chunks.extend([SEPARATOR, f"MSG: {canonical_type}", source_text.rstrip("\n")])
+        chunks.extend(
+            [
+                SEPARATOR,
+                f"MSG: {bundle_resource_name(canonical_type)}",
+                source_text.rstrip("\n"),
+            ]
+        )
     return "\n".join(chunks) + "\n"
 
 


### PR DESCRIPTION
Fix ros2msg bundle dependency headers to emit `MSG: package/Type` instead of `MSG: package/msg/Type`. Keep the three-part form only for internal lookup. Update regression tests and documentation accordingly.