### PR TITLE
Validate dynamic PDU allocation sizes before narrowing to int

### DIFF
--- a/pdu/types/pdu_dynamic_memory.hpp
+++ b/pdu/types/pdu_dynamic_memory.hpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 
 // Class to manage dynamic memory for PDU
@@ -26,14 +27,39 @@ public:
         }
     }
 
-    // Allocate memory and store the allocation info
+    // Allocate memory and store the allocation info.
+    //
+    // Dynamic PDU length/offset fields are part of the existing binary contract
+    // and are represented as int. Compute allocation sizes in size_t, validate
+    // that they fit in the 32-bit-compatible PDU offset domain, then convert
+    // explicitly so platform compilers cannot silently narrow the value.
     void* allocate(int length, size_t elem_size) {
-        void* ptr = malloc(length * elem_size);
+        if (length < 0) {
+            throw std::invalid_argument("PDU dynamic allocation length must be non-negative");
+        }
+
+        const size_t count = static_cast<size_t>(length);
+        if (count != 0 && elem_size > std::numeric_limits<size_t>::max() / count) {
+            throw std::overflow_error("PDU dynamic allocation size overflow");
+        }
+
+        const size_t byte_size = count * elem_size;
+        const size_t max_pdu_offset = static_cast<size_t>(std::numeric_limits<int>::max());
+        if (byte_size > max_pdu_offset) {
+            throw std::overflow_error("PDU dynamic allocation exceeds int-sized length");
+        }
+
+        const int allocation_size = static_cast<int>(byte_size);
+        if (current_offset > std::numeric_limits<int>::max() - allocation_size) {
+            throw std::overflow_error("PDU dynamic allocation exceeds int-sized offset range");
+        }
+
+        void* ptr = malloc(byte_size);
         if (ptr == nullptr) {
             throw std::runtime_error("Memory allocation failed");
         }
-        allocations.emplace_back(length * elem_size, current_offset, ptr);
-        current_offset += length * elem_size;
+        allocations.emplace_back(allocation_size, current_offset, ptr);
+        current_offset += allocation_size;
         return ptr;
     }
 


### PR DESCRIPTION
## Summary

Fix MSVC C4267 warnings in `PduDynamicMemory` without changing the existing PDU binary contract.

The warnings were found while building `hakoniwa-conductor-light` on Windows. `PduDynamicMemory::allocate()` computes byte sizes using `size_t`, while dynamic PDU length/offset fields are intentionally represented as `int` in the current binary layout.

## Changes

- keep `Allocation::length`, `Allocation::offset`, `current_offset`, `get_total_size()`, and `get_offset()` as `int`
- compute allocation byte size in `size_t`
- reject negative lengths
- detect `size_t` multiplication overflow
- verify one allocation fits in the existing `int` length domain
- verify cumulative offsets stay within the existing `int` offset domain
- perform an explicit checked conversion to `int` before storing the allocation

## Why not change the fields to `size_t`?

The generated PDU layout uses `int _<field>_len` and `int _<field>_off` for variable-length arrays. Changing the runtime helper to `size_t` would diverge from that established binary contract and could hide a compatibility change.

This PR therefore makes the narrowing explicit and safe rather than changing the on-wire/in-memory representation.

## Validation

The motivating validation is the Windows build of `hakoniwa-conductor-light`, where MSVC currently reports repeated C4267 warnings from this header through RPC/converter translation units. After updating the registry submodule to this branch, rebuilding Conductor Light on Windows should remove those warnings while preserving the current PDU layout.