### PR TITLE
Add ROS 2 .action to Hakoniwa .msg generator

### DIFF
--- a/generators/generate_hako_action_msgs/action_context.py
+++ b/generators/generate_hako_action_msgs/action_context.py
@@ -1,0 +1,20 @@
+import os
+
+
+class ActionContext:
+    def __init__(self, action_file_path, header_package_name=None):
+        if not os.path.isfile(action_file_path):
+            raise ValueError(
+                f"Error: '{action_file_path}' is not a valid .action file "
+                "(file does not exist or is not a regular file)."
+            )
+        if not action_file_path.endswith(".action"):
+            raise ValueError(f"Error: '{action_file_path}' must have a .action extension.")
+
+        self.action_file_path = action_file_path
+        self.action_name = os.path.splitext(os.path.basename(action_file_path))[0]
+        self.action_package_name = os.path.basename(os.path.dirname(action_file_path))
+        self.msg_package_name = f"{self.action_package_name}_msgs"
+        self.header_package_name = header_package_name or os.getenv(
+            "HAKO_ACTION_HEADER_PKG", "hako_action_msgs"
+        )

--- a/generators/generate_hako_action_msgs/action_parser.py
+++ b/generators/generate_hako_action_msgs/action_parser.py
@@ -1,0 +1,57 @@
+class ActionParser:
+    def __init__(self, context):
+        self.context = context
+
+    def parse(self):
+        sections = [[]]
+        with open(self.context.action_file_path, "r", encoding="utf-8") as action_file:
+            for raw_line in action_file:
+                line = raw_line.split("#", 1)[0].strip()
+                if not line:
+                    continue
+                if line == "---":
+                    sections.append([])
+                    continue
+                if "=" in line:
+                    # Hakoniwa PDU IDL does not support ROS constants.
+                    continue
+                sections[-1].append(self._parse_field(line))
+
+        if len(sections) != 3:
+            raise ValueError(
+                "Invalid .action definition: expected exactly two '---' separators "
+                "for Goal, Result, and Feedback sections."
+            )
+        return tuple(sections)
+
+    def _parse_field(self, line):
+        tokens = line.split()
+        if len(tokens) != 2:
+            raise ValueError(f"Invalid field line: '{line}'")
+
+        field_type, field_name = tokens
+        is_array = False
+        array_size = None
+        if field_type.endswith("]") and "[" in field_type:
+            base_type, array_spec = field_type.rsplit("[", 1)
+            array_spec = array_spec[:-1]
+            is_array = True
+            if array_spec:
+                if array_spec.startswith("<="):
+                    raise ValueError(
+                        f"Bounded arrays are not supported by the current PDU generator: '{line}'"
+                    )
+                array_size = int(array_spec)
+            field_type = base_type
+
+        package = None
+        if "/" in field_type:
+            package, field_type = field_type.split("/", 1)
+
+        return {
+            "type": field_type,
+            "name": field_name,
+            "package": package,
+            "is_array": is_array,
+            "array_size": array_size,
+        }

--- a/generators/generate_hako_action_msgs/main.py
+++ b/generators/generate_hako_action_msgs/main.py
@@ -1,0 +1,32 @@
+import argparse
+
+from generators.generate_hako_action_msgs.action_context import ActionContext
+from generators.generate_hako_action_msgs.action_parser import ActionParser
+from generators.generate_hako_action_msgs.msg_generator import MsgGenerator
+from generators.generate_hako_action_msgs.msg_writer import MsgWriter
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Hakoniwa Action .msg files from a ROS 2 .action file"
+    )
+    parser.add_argument("action_file", help="Path to the input .action file")
+    parser.add_argument("--out", required=True, help="Base output directory")
+    args = parser.parse_args()
+
+    context = ActionContext(args.action_file)
+    goal_fields, result_fields, feedback_fields = ActionParser(context).parse()
+    generator = MsgGenerator(context)
+    writer = MsgWriter(context, args.out)
+    name = context.action_name
+
+    writer.write(f"{name}Goal.msg", generator.generate_data_msg(goal_fields))
+    writer.write(f"{name}Result.msg", generator.generate_data_msg(result_fields))
+    writer.write(f"{name}Feedback.msg", generator.generate_data_msg(feedback_fields))
+    writer.write(f"{name}ActionRequest.msg", generator.generate_request_msg())
+    writer.write(f"{name}ActionResponse.msg", generator.generate_response_msg())
+    writer.write(f"{name}ActionFeedback.msg", generator.generate_feedback_msg())
+
+
+if __name__ == "__main__":
+    main()

--- a/generators/generate_hako_action_msgs/msg_generator.py
+++ b/generators/generate_hako_action_msgs/msg_generator.py
@@ -1,0 +1,43 @@
+PRIMITIVES = {
+    "bool", "int8", "uint8", "int16", "uint16", "int32", "uint32",
+    "int64", "uint64", "float32", "float64", "string", "char", "byte",
+    "time", "duration",
+}
+
+
+class MsgGenerator:
+    def __init__(self, context):
+        self.context = context
+
+    def generate_data_msg(self, fields):
+        lines = []
+        for field in fields:
+            package = field.get("package") or self.context.msg_package_name
+            typename = self._qualify(field["type"], package)
+            if field.get("is_array"):
+                size = field.get("array_size")
+                typename += f"[{size}]" if size is not None else "[]"
+            lines.append(f"{typename} {field['name']}")
+        return "\n".join(lines)
+
+    def generate_request_msg(self):
+        return self._packet("ActionRequestHeader", self.context.action_name + "Goal")
+
+    def generate_response_msg(self):
+        return self._packet("ActionResponseHeader", self.context.action_name + "Result")
+
+    def generate_feedback_msg(self):
+        return self._packet("ActionFeedbackHeader", self.context.action_name + "Feedback")
+
+    def _packet(self, header_type, body_type):
+        return "\n".join([
+            f"{self.context.header_package_name}/{header_type} header",
+            f"{body_type} body",
+        ])
+
+    def _qualify(self, typename, package):
+        if "/" in typename or typename in PRIMITIVES:
+            return typename
+        if package == self.context.msg_package_name:
+            return typename
+        return f"{package}/{typename}" if package else typename

--- a/generators/generate_hako_action_msgs/msg_writer.py
+++ b/generators/generate_hako_action_msgs/msg_writer.py
@@ -1,0 +1,12 @@
+import os
+
+
+class MsgWriter:
+    def __init__(self, context, output_base_dir):
+        self.output_dir = os.path.join(output_base_dir, context.msg_package_name, "msg")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def write(self, filename, content):
+        path = os.path.join(self.output_dir, filename)
+        with open(path, "w", encoding="utf-8") as output_file:
+            output_file.write(content + "\n")

--- a/tests/test_generate_hako_action_msgs.py
+++ b/tests/test_generate_hako_action_msgs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class GenerateHakoActionMsgsTest(unittest.TestCase):
+    def test_generates_six_messages(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            action_dir = root / "example_actions"
+            action_dir.mkdir()
+            action_file = action_dir / "Fibonacci.action"
+            action_file.write_text(
+                "int32 order\n"
+                "---\n"
+                "int32[] sequence\n"
+                "---\n"
+                "int32[] partial_sequence\n",
+                encoding="utf-8",
+            )
+            output = root / "out"
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "generators.generate_hako_action_msgs.main",
+                    str(action_file),
+                    "--out",
+                    str(output),
+                ],
+                cwd=ROOT,
+                check=True,
+            )
+
+            msg_dir = output / "example_actions_msgs" / "msg"
+            expected = {
+                "FibonacciGoal.msg": "int32 order\n",
+                "FibonacciResult.msg": "int32[] sequence\n",
+                "FibonacciFeedback.msg": "int32[] partial_sequence\n",
+                "FibonacciActionRequest.msg": (
+                    "hako_action_msgs/ActionRequestHeader header\n"
+                    "FibonacciGoal body\n"
+                ),
+                "FibonacciActionResponse.msg": (
+                    "hako_action_msgs/ActionResponseHeader header\n"
+                    "FibonacciResult body\n"
+                ),
+                "FibonacciActionFeedback.msg": (
+                    "hako_action_msgs/ActionFeedbackHeader header\n"
+                    "FibonacciFeedback body\n"
+                ),
+            }
+            self.assertEqual({path.name for path in msg_dir.glob("*.msg")}, set(expected))
+            for filename, content in expected.items():
+                self.assertEqual((msg_dir / filename).read_text(encoding="utf-8"), content)
+
+    def test_requires_exactly_three_sections(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            action_dir = root / "example_actions"
+            action_dir.mkdir()
+            action_file = action_dir / "Broken.action"
+            action_file.write_text("int32 value\n---\nint32 result\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "generators.generate_hako_action_msgs.main",
+                    str(action_file),
+                    "--out",
+                    str(root / "out"),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("exactly two '---' separators", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

ROS 2の`.action`定義から、箱庭の通常PDU生成ルートへ入力できる6つの`.msg`を生成するフロントエンドを追加します。

Closes #19

## 生成物

`Fibonacci.action`から次を生成します。

```text
FibonacciGoal.msg
FibonacciResult.msg
FibonacciFeedback.msg
FibonacciActionRequest.msg
FibonacciActionResponse.msg
FibonacciActionFeedback.msg
```

通信ラッパーは、#18で追加した共通Actionヘッダをネストします。

```text
hako_action_msgs/ActionRequestHeader header
FibonacciGoal body
```

## 実装方針

- 既存`generate_hako_service_msgs`と同じフロントエンド構成
- `.action`をGoal / Result / Feedbackの3区画へ分割
- 出力は通常の`.msg`のみ
- Action専用のC++、Python、offset、size生成器は追加しない
- 後段は既存`generate_hako_pdu_msgs`へ委譲
- PDU IDLで未対応のROS定数行は生成対象から除外

## 検証

- Fibonacci相当のActionから6ファイルが生成されるテスト
- ファイル名と内容の完全一致テスト
- 区切りが不足する不正Actionの失敗テスト

このPRではPDU変換と全体ツール統合は行いません。それらは#20、#21で扱います。